### PR TITLE
Creating one link to the set resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ In the code-along above, we built our own implementation of the `#each` method. 
 
 You can read more about the `yield` keyword and blocks in Ruby from the resources below:
 
-* [All About Ruby](http://allaboutruby.wordpress.com/) - [Ruby Blocks](http://allaboutruby.wordpress.com/2006/01/20/ruby-blocks-101/)
-* [Reactive's Tips](http://www.reactive.io/tips/) - [Understanding Ruby Blocks, Procs, and Lambdas](http://www.reactive.io/tips/2008/12/21/understanding-ruby-blocks-procs-and-lambdas)
-* [Mix&Go](https://mixandgo.com/) - [Mastering-ruby-blocks-in-less-than-5-minutes](https://mixandgo.com/blog/mastering-ruby-blocks-in-less-than-5-minutes)
+* [All About Ruby - Ruby Blocks](http://allaboutruby.wordpress.com/2006/01/20/ruby-blocks-101/)
+* [Reactive's Tips - Understanding Ruby Blocks, Procs, and Lambdas](http://www.reactive.io/tips/2008/12/21/understanding-ruby-blocks-procs-and-lambdas)
+* [Mix&Go - Mastering-ruby-blocks-in-less-than-5-minutes](https://mixandgo.com/blog/mastering-ruby-blocks-in-less-than-5-minutes)
 
 <p data-visibility='hidden'>View <a href='https://learn.co/lessons/yield-and-blocks' title='Yield and Blocks'>Yield and Blocks</a> on Learn.co and start learning to code for free.</p>

--- a/lib/hello.rb
+++ b/lib/hello.rb
@@ -1,6 +1,19 @@
-def hello_t
-
+def hello_t(array)
+  if block_given?
+i = 0
+while i <array.length
+  yield array[i]
+  i+=1
+  end
+else
+  puts "Hey! No block was given!"
+end
+return array
 end
 
 # call your method here!
-
+hello_t(["Tim", "Tom", "Jim"]) do |name|
+  if name.start_with?("T")
+    puts "Hi, #{name}"
+  end
+end


### PR DESCRIPTION
Instead of creating tow links to each resource ( the general site and the specific page for the topic), the suggestion can be made for just one link. Besides the user can look around if they want to, but they most likely click on the link to  get information about the specific topic ... not a general site.